### PR TITLE
Fix createApiComponents typing and api table pagination config

### DIFF
--- a/packages/api-admin/src/lib/components/Table/hooks/useApiTablePagination.ts
+++ b/packages/api-admin/src/lib/components/Table/hooks/useApiTablePagination.ts
@@ -1,4 +1,5 @@
 import { UncapitalizeDeep } from "@leancodepl/utils";
+import { TablePaginationConfig } from "antd";
 import { useCallback, useMemo } from "react";
 import usePagination from "../../../hooks/usePagination";
 import { AdminQuery, AdminQueryResult } from "../../../types/admin";
@@ -10,8 +11,8 @@ export const defaultPaginationConfig = {
   current: 1,
 };
 
-export function useApiTablePagination<T>() {
-  const { pagination: paginationHandler, useSetTotal } = usePagination();
+export function useApiTablePagination<T>({ defaultPageSize }: { defaultPageSize?: number } = {}) {
+  const { pagination: paginationHandler, useSetTotal } = usePagination({ initialPageSize: defaultPageSize });
 
   const paginationQueryParams = useMemo<Pick<AdminQuery<T>, "PageSize" | "Page">>(
     () => ({
@@ -22,8 +23,9 @@ export function useApiTablePagination<T>() {
   );
 
   const getPaginationConfig = useCallback(
-    (data: UncapitalizeDeep<AdminQueryResult<T>> | undefined | null) => ({
+    (data: UncapitalizeDeep<AdminQueryResult<T>> | undefined | null, pagination?: ApiTablePaginationConfig) => ({
       ...defaultPaginationConfig,
+      ...pagination,
       onChange: (page: number, pageSize: number) => {
         paginationHandler.onPageChange(page);
         paginationHandler.onPageSizeChange(pageSize);
@@ -42,3 +44,5 @@ export function useApiTablePagination<T>() {
     paginationQueryParams,
   };
 }
+
+export type ApiTablePaginationConfig = Omit<TablePaginationConfig, "onChange" | "pageSize" | "current" | "total">;

--- a/packages/api-admin/src/lib/components/Table/index.tsx
+++ b/packages/api-admin/src/lib/components/Table/index.tsx
@@ -170,7 +170,7 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
 
 export function mkApiTables<
   TAdminComponentsConfig extends AdminComponentsConfig,
-  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, (...param: any) => any>,
+  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, unknown>,
 >(
   { components, enumsMaps }: TAdminComponentsConfig,
   { cqrsClientConfig, cqrs }: { cqrsClientConfig: CqrsClientConfig; cqrs: TCqrs },

--- a/packages/api-admin/src/lib/components/Table/index.tsx
+++ b/packages/api-admin/src/lib/components/Table/index.tsx
@@ -7,7 +7,7 @@ import type {
   EnumsMap,
 } from "@leancodepl/contractsgenerator-typescript-plugin-admin";
 import { mkCqrsClient } from "@leancodepl/react-query-cqrs-client";
-import { assertNotEmpty, toLowerFirst } from "@leancodepl/utils";
+import { UncapitalizeDeep, assertNotEmpty, toLowerFirst } from "@leancodepl/utils";
 import { keepPreviousData } from "@tanstack/react-query";
 import { Table as AntTable, TableProps as AntTableProps, TableColumnType, TableProps } from "antd";
 import { ReactNode, useCallback, useMemo, useState } from "react";
@@ -17,20 +17,21 @@ import { useApiTablePagination } from "./hooks/useApiTablePagination";
 import { useApiTableSorting } from "./hooks/useApiTableSorting";
 import { CqrsClientConfig } from "../../createApiComponents";
 import { AdminQuery, AdminQueryResult } from "../../types/admin";
-import { GetAllQueries, GetAllTables, GetTableByQuery, GetQuery } from "../../types/components";
+import { GetAllQueries, GetAllTables, GetTableByQuery } from "../../types/components";
 
 const __createQueryType: ReturnType<typeof mkCqrsClient>["createQuery"] = null as any;
-type CreateQueryResult = ReturnType<typeof __createQueryType<AdminQuery<any>, AdminQueryResult<any>>>;
+type CreateAdminQueryResult<TRecord> = CreateQueryResult<AdminQuery<TRecord>, AdminQueryResult<TRecord>>;
 
-type PoorsManApiClient = Record<string, CreateQueryResult>;
+export type CreateQueryResult<TQuery, TResult> = ReturnType<typeof __createQueryType<TQuery, TResult>>;
 
-function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends AdminQuery<any>>(
+export type PoorsManApiClient = Record<string, CreateAdminQueryResult<any>>;
+
+function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends AdminQuery<any>, TRecord>(
   { query, columns }: TAdminTable,
   apiClient: PoorsManApiClient,
   enumsMap: EnumsMap,
 ) {
   type TQueryParams = Omit<TQueryConfig, keyof AdminQuery<any>>;
-  type TQueryResponse = TQueryConfig extends AdminQuery<infer TResult> ? TResult : never;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   type TQueryParamsProps = {} extends TQueryParams ? { requestParams?: TQueryParams } : { requestParams: TQueryParams };
@@ -43,13 +44,13 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
 
   type ColumnProps<TColumn> = TColumn extends AdminTableColumn
     ? {
-        [TKey in `${TColumn["id"]}Render`]?: (value: unknown, record: TQueryResponse) => ReactNode;
+        [TKey in `${TColumn["id"]}Render`]?: (value: unknown, record: TRecord) => ReactNode;
       } & {
-        [TKey in `${TColumn["id"]}Filter`]?: TColumn["filter"] extends undefined ? never : FilterConfig<TQueryResponse>;
+        [TKey in `${TColumn["id"]}Filter`]?: TColumn["filter"] extends undefined ? never : FilterConfig<TRecord>;
       }
     : never;
 
-  type ApiTableProps = Omit<AntTableProps<unknown>, "columns" | "dataSource" | "loading" | "pagination" | "onChange"> &
+  type ApiTableProps = Omit<AntTableProps<TRecord>, "columns" | "dataSource" | "loading" | "pagination" | "onChange"> &
     TQueryParamsProps &
     ColumnsProps;
 
@@ -65,7 +66,7 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
       string,
       {
         render: (value: any, record: any) => ReactNode;
-        filter?: FilterConfig<TQueryResponse>;
+        filter?: FilterConfig<TRecord>;
       }
     >,
   );
@@ -73,9 +74,9 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
   const useQuery = apiClient[query];
 
   function ApiTable({ requestParams, ...props }: ApiTableProps) {
-    const { getPaginationConfig, paginationQueryParams, useSetTotal } = useApiTablePagination<TQueryResponse>();
+    const { getPaginationConfig, paginationQueryParams, useSetTotal } = useApiTablePagination<TRecord>();
 
-    const { sortData, sortQueryParams } = useApiTableSorting<TQueryResponse>();
+    const { sortData, sortQueryParams } = useApiTableSorting<TRecord>();
 
     const [filtersQueryParams, setFiltersQueryParams] = useState<Record<string, unknown>>({});
 
@@ -119,7 +120,7 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
       [props, sortData?.sortData?.columnKey, sortData?.sortData?.order],
     );
 
-    const onChange = useCallback<Exclude<TableProps<TQueryResponse>["onChange"], undefined>>(
+    const onChange = useCallback<Exclude<TableProps<TRecord>["onChange"], undefined>>(
       (_pagination, filters, sorter) => {
         // Sort
         sortData?.onSortDataChange(Array.isArray(sorter) ? sorter[0] : sorter);
@@ -164,19 +165,23 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
 
 export function mkApiTables<
   TAdminComponentsConfig extends AdminComponentsConfig,
-  TContracts extends Record<GetAllQueries<GetAllTables<TAdminComponentsConfig>>, AdminQuery<any>>,
+  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, (...param: any) => any>,
 >(
   { components, enumsMaps }: TAdminComponentsConfig,
-  { cqrsClientConfig, cqrs }: { cqrsClientConfig: CqrsClientConfig; cqrs: any },
+  { cqrsClientConfig, cqrs }: { cqrsClientConfig: CqrsClientConfig; cqrs: TCqrs },
 ): {
   [TQuery in GetAllQueries<GetAllTables<TAdminComponentsConfig>> as `${TQuery}ApiTable`]: ReturnType<
-    typeof mkApiTable<GetTableByQuery<GetAllTables<TAdminComponentsConfig>, TQuery>, GetQuery<TContracts, TQuery>>
+    typeof mkApiTable<
+      GetTableByQuery<GetAllTables<TAdminComponentsConfig>, TQuery>,
+      GetAdminQuery<ReturnType<TCqrs>, TQuery>,
+      GetAdminQueryRecord<ReturnType<TCqrs>, TQuery>
+    >
   >;
 } {
   const apiTables = {} as any;
 
   const cqrsClient = mkCqrsClient(cqrsClientConfig);
-  const apiClient = cqrs(cqrsClient);
+  const apiClient = cqrs(cqrsClient) as PoorsManApiClient;
 
   components.forEach(adminTableApiComponent => {
     apiTables[`${adminTableApiComponent.table.query}ApiTable`] = mkApiTable(
@@ -188,3 +193,21 @@ export function mkApiTables<
 
   return apiTables;
 }
+
+type GetAdminQuery<
+  TCqrs extends Record<string, unknown>,
+  TQueryKey extends string,
+> = TCqrs[TQueryKey] extends CreateQueryResult<infer TQuery, any>
+  ? TQuery extends AdminQuery<any>
+    ? TQuery
+    : AdminQuery<any>
+  : AdminQuery<any>;
+
+type GetAdminQueryRecord<
+  TCqrs extends Record<string, unknown>,
+  TQueryKey extends string,
+> = TCqrs[TQueryKey] extends CreateQueryResult<any, infer TResult>
+  ? TResult extends UncapitalizeDeep<AdminQueryResult<infer TRecord>>
+    ? TRecord
+    : unknown
+  : unknown;

--- a/packages/api-admin/src/lib/components/Table/index.tsx
+++ b/packages/api-admin/src/lib/components/Table/index.tsx
@@ -20,11 +20,11 @@ import { AdminQuery, AdminQueryResult } from "../../types/admin";
 import { GetAllQueries, GetAllTables, GetTableByQuery } from "../../types/components";
 
 const __createQueryType: ReturnType<typeof mkCqrsClient>["createQuery"] = null as any;
+
+type CreateQueryResult<TQuery, TResult> = ReturnType<typeof __createQueryType<TQuery, TResult>>;
 type CreateAdminQueryResult<TRecord> = CreateQueryResult<AdminQuery<TRecord>, AdminQueryResult<TRecord>>;
 
-export type CreateQueryResult<TQuery, TResult> = ReturnType<typeof __createQueryType<TQuery, TResult>>;
-
-export type PoorsManApiClient = Record<string, CreateAdminQueryResult<any>>;
+type PoorsManApiClient = Record<string, CreateAdminQueryResult<any>>;
 
 function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends AdminQuery<any>, TRecord>(
   { query, columns }: TAdminTable,
@@ -100,8 +100,6 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
       () => getPaginationConfig(data, props.pagination),
       [data, getPaginationConfig, props.pagination],
     );
-
-    console.log(paginationConfig);
 
     const columns2 = useMemo(
       () =>

--- a/packages/api-admin/src/lib/components/Table/index.tsx
+++ b/packages/api-admin/src/lib/components/Table/index.tsx
@@ -13,7 +13,7 @@ import { Table as AntTable, TableProps as AntTableProps, TableColumnType, TableP
 import { ReactNode, useCallback, useMemo, useState } from "react";
 import { mkColumnRender } from "./filters/mkColumnRender";
 import { FilterConfig, mkFilterConfig } from "./filters/mkFilterConfig";
-import { useApiTablePagination } from "./hooks/useApiTablePagination";
+import { ApiTablePaginationConfig, useApiTablePagination } from "./hooks/useApiTablePagination";
 import { useApiTableSorting } from "./hooks/useApiTableSorting";
 import { CqrsClientConfig } from "../../createApiComponents";
 import { AdminQuery, AdminQueryResult } from "../../types/admin";
@@ -52,7 +52,7 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
 
   type ApiTableProps = Omit<AntTableProps<TRecord>, "columns" | "dataSource" | "loading" | "pagination" | "onChange"> &
     TQueryParamsProps &
-    ColumnsProps;
+    ColumnsProps & { pagination?: ApiTablePaginationConfig };
 
   const columnsDefaults = columns.reduce(
     (defaults, column) => ({
@@ -74,7 +74,9 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
   const useQuery = apiClient[query];
 
   function ApiTable({ requestParams, ...props }: ApiTableProps) {
-    const { getPaginationConfig, paginationQueryParams, useSetTotal } = useApiTablePagination<TRecord>();
+    const { getPaginationConfig, paginationQueryParams, useSetTotal } = useApiTablePagination<TRecord>({
+      defaultPageSize: props.pagination?.defaultPageSize,
+    });
 
     const { sortData, sortQueryParams } = useApiTableSorting<TRecord>();
 
@@ -94,7 +96,12 @@ function mkApiTable<TAdminTable extends AdminTableConfig, TQueryConfig extends A
 
     useSetTotal(data?.total);
 
-    const paginationConfig = useMemo(() => getPaginationConfig(data), [data, getPaginationConfig]);
+    const paginationConfig = useMemo(
+      () => getPaginationConfig(data, props.pagination),
+      [data, getPaginationConfig, props.pagination],
+    );
+
+    console.log(paginationConfig);
 
     const columns2 = useMemo(
       () =>

--- a/packages/api-admin/src/lib/createApiComponents.ts
+++ b/packages/api-admin/src/lib/createApiComponents.ts
@@ -2,22 +2,17 @@
 import { AdminComponentsConfig } from "@leancodepl/contractsgenerator-typescript-plugin-admin";
 import { mkCqrsClient } from "@leancodepl/react-query-cqrs-client";
 import { mkApiTables } from "./components/Table";
-import { AdminQuery } from "./types/admin";
-import { GetAllQueries, GetAllTables } from "./types/components";
 
 export type CqrsClientConfig = Parameters<typeof mkCqrsClient>[0];
 
 export function createApiComponents<
   TAdminComponentsConfig extends AdminComponentsConfig,
-  TContracts extends Record<GetAllQueries<GetAllTables<TAdminComponentsConfig>>, AdminQuery<any>>,
+  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, (...params: any) => any>,
 >(
   { components, enumsMaps }: TAdminComponentsConfig,
-  {
-    cqrsClientConfig,
-    cqrs,
-  }: { cqrsClientConfig: CqrsClientConfig; cqrs: (cqrsClient: ReturnType<typeof mkCqrsClient>) => any },
-) {
-  return mkApiTables<TAdminComponentsConfig, TContracts>({ components, enumsMaps } as TAdminComponentsConfig, {
+  { cqrsClientConfig, cqrs }: { cqrsClientConfig: CqrsClientConfig; cqrs: TCqrs },
+): ReturnType<typeof mkApiTables<TAdminComponentsConfig, TCqrs>> {
+  return mkApiTables<TAdminComponentsConfig, TCqrs>({ components, enumsMaps } as TAdminComponentsConfig, {
     cqrsClientConfig,
     cqrs,
   });

--- a/packages/api-admin/src/lib/createApiComponents.ts
+++ b/packages/api-admin/src/lib/createApiComponents.ts
@@ -7,7 +7,7 @@ export type CqrsClientConfig = Parameters<typeof mkCqrsClient>[0];
 
 export function createApiComponents<
   TAdminComponentsConfig extends AdminComponentsConfig,
-  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, (...params: any) => any>,
+  TCqrs extends (cqrsClient: ReturnType<typeof mkCqrsClient>) => Record<string, unknown>,
 >(
   { components, enumsMaps }: TAdminComponentsConfig,
   { cqrsClientConfig, cqrs }: { cqrsClientConfig: CqrsClientConfig; cqrs: TCqrs },

--- a/packages/api-admin/src/lib/hooks/usePagination.ts
+++ b/packages/api-admin/src/lib/hooks/usePagination.ts
@@ -40,7 +40,7 @@ export default function usePagination({
       if (paginationRef.current) paginationRef.current.total = total;
 
       if (total !== undefined) {
-        const totalPages = Math.ceil(total / pageSize);
+        const totalPages = Math.max(Math.ceil(total / pageSize), 1);
 
         if (totalPages < displayPage) {
           setDisplayPage(totalPages);

--- a/packages/api-admin/src/lib/types/admin.ts
+++ b/packages/api-admin/src/lib/types/admin.ts
@@ -14,5 +14,5 @@ export interface AdminQuery<TResult> extends Query<AdminQueryResult<TResult>> {
 
 export interface AdminQueryResult<TResult> {
   Total: number;
-  Items: TResult;
+  Items: TResult[];
 }


### PR DESCRIPTION
It works for 2 tables, I hope it works for more. If it doesn't then we would probably have to drop getting `TRecord` in `mkApiTable`