### PR TITLE
Allow overriding shell for generate.sh script, override default shell on windows

### DIFF
--- a/packages/generator/src/getSchema.ts
+++ b/packages/generator/src/getSchema.ts
@@ -2,6 +2,7 @@ import { GeneratorInput } from "@leancodepl/contractsgenerator-typescript-plugin
 import { GeneratorSchema, parseSchema } from "@leancodepl/contractsgenerator-typescript-schema";
 import { exec } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { platform } from "node:os";
 import { join, resolve } from "node:path";
 
 export const serverContractsGeneratorVersion = "3.0.0-alpha.3";
@@ -58,6 +59,7 @@ export async function getSchema(input: GeneratorInput) {
       `${serverVersion} "${script}" ${params}`,
       {
         encoding: "buffer",
+        shell: inferShell(),
       },
       (error, stdout) => {
         if (error) {
@@ -69,4 +71,20 @@ export async function getSchema(input: GeneratorInput) {
       },
     );
   });
+}
+
+function inferShell(): string | undefined {
+  const shellEnv = process.env.CONTRACTS_GENERATOR_SHELL;
+
+  if (shellEnv) {
+    return shellEnv;
+  }
+
+  // Minimal support for Git Bash on Windows
+
+  if (platform() === "win32") {
+    return "bash";
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
On windows node will pick up `cmd.exe` as the shell process, which makes it impossible to use it even with git bash. There is a possibility to set shell via `ComSpec` but Windows does not really like it to be changed. So I set the default for windows and also allow it to be overridden if needed. 

This will probably get obsoleted if we support [overriding generator binary](https://github.com/leancodepl/contractsgenerator-typescript/issues/129) 